### PR TITLE
Update _interface.scss

### DIFF
--- a/app-source/scss/partials/_interface.scss
+++ b/app-source/scss/partials/_interface.scss
@@ -281,8 +281,8 @@ aside {
 	
 	border: 0;
 	border-radius: 0;
-	height: 39px;
-    margin-top: 3px;
+	height: 59px;
+        margin-top: 3px;
 	overflow-x: scroll;
 	overflow-y: hidden;
 	text-align: center;


### PR DESCRIPTION
On my MBP 2017 the .editor-toolbar is cut in half so only part of the icons show up.  I extended the height from 39px to 59px.  